### PR TITLE
Remove alternative_namespace needs for NexusClient initialization when not relevant

### DIFF
--- a/pyxus/pyxus/client.py
+++ b/pyxus/pyxus/client.py
@@ -30,7 +30,7 @@ class NexusClient(object):
         self.logger = logging.getLogger(__name__)
         self.namespace = alternative_namespace if alternative_namespace is not None else "{}://{}".format(scheme, host)
         self.env = None
-        self.config = NexusConfig(scheme, host, prefix, alternative_namespace)
+        self.config = NexusConfig(scheme, host, prefix, self.namespace)
         self._http_client = HttpClient(self.config.NEXUS_ENDPOINT, self.config.NEXUS_PREFIX, auth_client=auth_client,
                                        alternative_endpoint_writing=self.config.NEXUS_NAMESPACE)
         self.domains = DomainRepository(self._http_client)


### PR DESCRIPTION
Hi,

Unless I misunderstood something, I would say that in the following line, `alternative_namespace`should be replaced by `self.namespace` defined line 31 of the same file.

https://github.com/HumanBrainProject/pyxus/blob/f210d99803df17c7ac0c9e1fdcd8882c66c575c4/pyxus/pyxus/client.py#L33

Not doing so, requires the users (people or libraries) to do themself exactly what is done line 31: `{}://{}".format(scheme, host)` when there is no need for an alternative namespace.