### PR TITLE
Replace pystache with jinja2

### DIFF
--- a/pyxus/pyxus/utils/generic_data_upload_utils.py
+++ b/pyxus/pyxus/utils/generic_data_upload_utils.py
@@ -24,7 +24,7 @@ import json
 import logging
 import re
 
-import pystache
+import jinja2
 from requests.exceptions import HTTPError
 
 from pyxus.client import NexusException
@@ -99,7 +99,7 @@ class GenericDataUploadUtils(object):
         # in our structure, the port is already included within the host string -
         # to make sure we don't have any broken namespaces, we have to remove it from the template
         template = template.replace(":{{port}}", "")
-        return pystache.render(template, base="{}/{}".format(
+        return jinja2.Template(template).render(base="{}/{}".format(
             self._client.config.NEXUS_NAMESPACE,
             self._client.config.NEXUS_PREFIX), prefix=self._client.config.NEXUS_PREFIX)
 

--- a/pyxus/requirements.txt
+++ b/pyxus/requirements.txt
@@ -2,7 +2,7 @@
 pyld==0.8.2
 rdflib==4.2.2
 rdflib-jsonld==0.4.0
-pystache
+jinja2
 pypandoc
 openid_http_client
 deepdiff

--- a/pyxus/setup.py
+++ b/pyxus/setup.py
@@ -36,7 +36,7 @@ setup(
     name='pyxus',
     version='0.5.1',
     packages=['pyxus', 'pyxus.resources', 'pyxus.utils'],
-    install_requires = ['pyld', 'rdflib', 'pystache', 'openid_http_client', 'rdflib-jsonld'],
+    install_requires = ['pyld', 'rdflib', 'jinja2', 'openid_http_client', 'rdflib-jsonld'],
     author='HumanBrainProject',
     scripts=['manage.py'],
     author_email = 'platform@humanbrainproject.eu',


### PR DESCRIPTION
since pystache is no longer maintained and cannot be installed with recent versions of setuptools.

```
pystache: using: version '58.2.0' of <module 'setuptools' from '/opt/app-root/lib/python3.6/site-packages/setuptools/__init__.py'>
  error in pystache setup command: use_2to3 is invalid.
```