### PR TITLE
pypandoc has removed the `convert()` function

### DIFF
--- a/pyxus/setup.py
+++ b/pyxus/setup.py
@@ -26,7 +26,7 @@ from setuptools import setup
 if os.path.exists("../README.md"):
     try:
         import pypandoc
-        long_description = pypandoc.convert('../README.md', 'rst')
+        long_description = pypandoc.convert_file('../README.md', 'rst')
     except(IOError, ImportError):
         long_description = open('../README.md').read()
 else:


### PR DESCRIPTION
and replaced it with `convert_file()` and `convert_text()`